### PR TITLE
Switch to using streaming metadata from gstreamer.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ setup(
     author='happyleaves',
     author_email='happyleaves.tfr@gmail.com',
     packages=['gsp'],
-    install_requires=['mutagen>=1.36.2'],
     classifiers=[
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',


### PR DESCRIPTION
Gstreamer can read the metadata tags without needing Mutagen. This is especially nice for things like internet radio as it can update the fields as new songs begin to play, etc. This also works as before for local files. 

- remove mutagen dependency
- handle tag messages to update metadata